### PR TITLE
Configure emg port for envoy

### DIFF
--- a/cli/lib/gateway.js
+++ b/cli/lib/gateway.js
@@ -141,6 +141,8 @@ Gateway.prototype.start = (options,cb) => {
                 args.pluginDir = path.resolve(config.edgemicro.plugins.dir);
             }
         }
+        // Passing envoy argument for implementing envoy proxy as sidecar.
+        args.envoy = options.envoy;
         opt.args = [JSON.stringify(args)];
         opt.timeout = 10;
         opt.logger = gateway.Logging.getLogger();

--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -3,6 +3,7 @@ const edgeConfig = require('microgateway-config');
 const agent = require('./server')();
 const fs = require('fs');
 const assert = require('assert');
+const EMG_PORT = 8002;
 //const path = require('path');
 //const cluster = require('cluster');
 
@@ -20,6 +21,9 @@ const getConfigStart = function getConfigStart(options, cb) {
   fs.exists(options.target, (exists) => {
     if (exists) {
       const config = edgeConfig.load({ source: options.target });
+      if(options.envoy && options.envoy === "yes"){
+        config.edgemicro.port = EMG_PORT;
+      }
       const keys = {key: config.analytics.key, secret: config.analytics.secret};
       startServer(keys, options.pluginDir, config, cb);
     } else {


### PR DESCRIPTION
Set emg port to 8002 if envoy proxy is enabled in edgemicro start cmd.