### PR TITLE
Start envoy proxy

### DIFF
--- a/lib/agent-config.js
+++ b/lib/agent-config.js
@@ -23,6 +23,7 @@ const getConfigStart = function getConfigStart(options, cb) {
       const config = edgeConfig.load({ source: options.target });
       if(options.envoy && options.envoy === "yes"){
         config.edgemicro.port = EMG_PORT;
+        config.edgemicro.useEnvoy = true;
       }
       const keys = {key: config.analytics.key, secret: config.analytics.secret};
       startServer(keys, options.pluginDir, config, cb);

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -65,6 +65,13 @@ Plugins.prototype.loadPlugins = function () {
 function _reorderPlugins(dirs, config) {
   const analytics = 'analytics';
 
+  let defaultPlugins = [ analytics ];
+
+  // enable envoy plugin
+  if ( config.edgemicro.useEnvoy ) {
+    defaultPlugins.push('envoy')
+  }
+
   const sequence = config.edgemicro.plugins.sequence || [];
 
   if (!Array.isArray(sequence)) {
@@ -73,7 +80,7 @@ function _reorderPlugins(dirs, config) {
 
   // ensure analytics is always present and is the first
   if (sequence.indexOf(analytics) < 0) {
-    sequence.unshift(analytics); // add first if not configured explicitly
+    sequence.unshift(...defaultPlugins); // add first if not configured explicitly
   } else {
     if (sequence[0] !== analytics) { // ensure first if configured explicitly
       throw new Error('analytics must be the first sequenced plugin');


### PR DESCRIPTION
If envoy is enabled in start command:
Assign edgemicro.port to envoy proxy.
Start envoy proxy server.
Enable 'envoy' plugin in seqence after 'analytics'